### PR TITLE
fix(access) correct short circuit conditional for query strings

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -231,7 +231,7 @@ end
 
 local function transform_querystrings(conf)
 
-  if not (#conf.remove.querystring > 0 or #conf.rename.querystring or
+  if not (#conf.remove.querystring > 0 or #conf.rename.querystring > 0 or
           #conf.replace.querystring > 0 or #conf.add.querystring > 0 or
           #conf.append.querystring > 0) then
     return


### PR DESCRIPTION
Short circuit mechanism for un-configured request transformer using query strings was improperly checking the `rename` query string configuration contents. This caused reserved words that should have remained un-encoded to be URL encoded by the unnecessary transform.

This fixes #23