### PR TITLE
fix(template) correctly construct error message when template throws Lua

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -99,6 +99,9 @@ local __meta_environment = {
 template_environment = setmetatable({
   -- here we can optionally add functions to expose to the sandbox, eg:
   -- tostring = tostring,  -- for example
+  -- because headers may contain array elements such as duplicated headers
+  -- type is a useful function in these cases. See issue #25.
+  type = type,
 }, __meta_environment)
 
 local function clear_environment(conf)

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -149,12 +149,12 @@ local function iter(config_array)
 
     local res, err = param_value(current_value, config_array)
     if err then
-      return error("[request-transformer] failed to render the template ",
-        current_value, ", error:", err)
+      return error("[request-transformer] failed to render the template " ..
+                   current_value .. ", error:" .. err)
     end
 
     kong.log.debug("[request-transformer] template `", current_value,
-      "` rendered to `", res, "`")
+                   "` rendered to `", res, "`")
 
     return i, current_name, res
   end, config_array, 0


### PR DESCRIPTION
error. That way the errr log will contain actual error messages from the
template closure. Previously the `error` function was used incorrectly
and incorrect Lua error was written into the logs instead. Fixes #25