### PR TITLE
feat: remove headers based on pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## UNRELEASED
+
+### Added
+
+- Ability to remove headers using a pattern
+
+
 ## 1.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ You can combine `consumer_id` and `service_id` in the same request, to furthermo
 | `consumer_id`                                     |                     | The id of the Consumer which this plugin will target.
 | `config.http_method`                              |                     | Changes the HTTP method for the upstream request
 | `config.remove.headers`                           |                     | List of header names. Unset the headers with the given name.
+| `config.remove.headers_match`                     |                     | List of header patterns. Unset the headers when the pattern matches the given name.
 | `config.remove.querystring`                       |                     | List of querystring names. Remove the querystring if it is present.
 | `config.remove.body`                              |                     | List of parameter names. Remove the parameter if and only if content-type is one the following [`application/json`,`multipart/form-data`, `application/x-www-form-urlencoded`] and parameter is present.
 | `config.replace.headers`                          |                     | List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can combine `consumer_id` and `service_id` in the same request, to furthermo
 | `consumer_id`                                     |                     | The id of the Consumer which this plugin will target.
 | `config.http_method`                              |                     | Changes the HTTP method for the upstream request
 | `config.remove.headers`                           |                     | List of header names. Unset the headers with the given name.
-| `config.remove.headers_match`                     |                     | List of header patterns. Unset the headers when the pattern matches the given name.
+| `config.remove.headers_pattern`                   |                     | List of header patterns. Unset the headers when the pattern matches the given name.
 | `config.remove.querystring`                       |                     | List of querystring names. Remove the querystring if it is present.
 | `config.remove.body`                              |                     | List of parameter names. Remove the parameter if and only if content-type is one the following [`application/json`,`multipart/form-data`, `application/x-www-form-urlencoded`] and parameter is present.
 | `config.replace.headers`                          |                     | List of headername:value pairs. If and only if the header is already set, replace its old value with the new one. Ignored if the header is not already set.

--- a/kong-plugin-request-transformer-1.3.0-0.rockspec
+++ b/kong-plugin-request-transformer-1.3.0-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong-plugin-request-transformer"
-version = "1.3.0-0"
+version = "1.3.0"
 
 source = {
   url = "git://github.com/Kong/kong-plugin-request-transformer",
-  tag = "1.3.0"
+  tag = "1.3.0-0"
 }
 
 supported_platforms = {"linux", "macosx"}

--- a/kong-plugin-request-transformer-1.3.0-0.rockspec
+++ b/kong-plugin-request-transformer-1.3.0-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong-plugin-request-transformer"
-version = "1.3.0"
+version = "1.3.0-0"
 
 source = {
   url = "git://github.com/Kong/kong-plugin-request-transformer",
-  tag = "1.3.0-0"
+  tag = "1.3.0"
 }
 
 supported_platforms = {"linux", "macosx"}

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -194,7 +194,7 @@ local function transform_headers(conf)
   for _, pattern, _ in iter(conf.remove.headers_match) do
     for name, _ in pairs(headers) do
       local match = name:find(pattern)
-      if match and match == 1 then
+      if match then
         headers[name] = nil
         headers_to_remove[name] = true
       end

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -183,11 +183,21 @@ local function transform_headers(conf)
   headers.host = nil
 
   -- Remove header(s)
-  for _, name, value in iter(conf.remove.headers) do
+  for _, name, _ in iter(conf.remove.headers) do
     name = name:lower()
     if headers[name] then
       headers[name] = nil
       headers_to_remove[name] = true
+    end
+  end
+
+  for _, pattern, _ in iter(conf.remove.headers_match) do
+    for name, _ in pairs(headers) do
+      local match = name:find(pattern)
+      if match and match == 1 then
+        headers[name] = nil
+        headers_to_remove[name] = true
+      end
     end
   end
 

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -192,8 +192,9 @@ local function transform_headers(conf)
   end
 
   for _, pattern, _ in iter(conf.remove.headers_pattern) do
+    pattern = pattern:lower()
     for name, _ in pairs(headers) do
-      local match = name:find(pattern:lower())
+      local match = name:find(pattern)
       if match then
         headers[name] = nil
         headers_to_remove[name] = true

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -191,7 +191,7 @@ local function transform_headers(conf)
     end
   end
 
-  for _, pattern, _ in iter(conf.remove.headers_match) do
+  for _, pattern, _ in iter(conf.remove.headers_pattern) do
     for name, _ in pairs(headers) do
       local match = name:find(pattern:lower())
       if match then

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -193,7 +193,7 @@ local function transform_headers(conf)
 
   for _, pattern, _ in iter(conf.remove.headers_match) do
     for name, _ in pairs(headers) do
-      local match = name:find(pattern)
+      local match = name:find(pattern:lower())
       if match then
         headers[name] = nil
         headers_to_remove[name] = true

--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -53,16 +53,15 @@ local headers_array = {
   elements = { type = "string", custom_validator = validate_headers },
 }
 
-
-local strings_array_record = {
+local remove_array_record = {
   type = "record",
   fields = {
     { body = strings_array },
     { headers = headers_array },
+    { headers_match = strings_array },
     { querystring = strings_array },
-  },
+  }
 }
-
 
 local colon_strings_array = {
   type = "array",
@@ -117,7 +116,7 @@ return {
         type = "record",
         fields = {
           { http_method = typedefs.http_method },
-          { remove  = strings_array_record },
+          { remove  = remove_array_record },
           { rename  = colon_rename_strings_array_record },
           { replace = colon_strings_array_record_plus_uri },
           { add     = colon_strings_array_record },

--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -58,7 +58,7 @@ local remove_array_record = {
   fields = {
     { body = strings_array },
     { headers = headers_array },
-    { headers_match = strings_array },
+    { headers_pattern = strings_array },
     { querystring = strings_array },
   }
 }

--- a/spec/02-access_spec.lua
+++ b/spec/02-access_spec.lua
@@ -156,7 +156,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       config = {
         remove = {
           headers = {"x-to-remove", "uber-trace-id"},
-          headers_match = {"^uberctx-"},
+          headers_pattern = {"^uberctx-"},
           querystring = {"q1"},
           body = {"toremoveform"}
         }

--- a/spec/02-access_spec.lua
+++ b/spec/02-access_spec.lua
@@ -155,7 +155,8 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       name = "request-transformer",
       config = {
         remove = {
-          headers = {"x-to-remove"},
+          headers = {"x-to-remove", "uber-trace-id"},
+          headers_match = {"uberctx-.*"},
           querystring = {"q1"},
           body = {"toremoveform"}
         }
@@ -483,13 +484,21 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
         headers = {
           host = "test4.com",
           ["x-to-remove"] = "true",
-          ["x-another-header"] = "true"
+          ["x-another-header"] = "true",
+          ["uber-trace-id"] = "true",
+          ["uberctx-foo"] = "true",
+          ["uberctx-bar"] = "true",
+          ["x-uberctx-spam"] = "true",
         }
       })
       assert.response(r).has.status(200)
       assert.response(r).has.jsonbody()
       assert.request(r).has.no.header("x-to-remove")
+      assert.request(r).has.no.header("uber-trace-id")
+      assert.request(r).has.no.header("uberctx-foo")
+      assert.request(r).has.no.header("uberctx-bar")
       assert.request(r).has.header("x-another-header")
+      assert.request(r).has.header("x-uberctx-spam")
     end)
     it("parameters on url encoded form POST", function()
       local r = assert(client:send {

--- a/spec/02-access_spec.lua
+++ b/spec/02-access_spec.lua
@@ -156,7 +156,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       config = {
         remove = {
           headers = {"x-to-remove", "uber-trace-id"},
-          headers_match = {"uberctx-.*"},
+          headers_match = {"^uberctx-"},
           querystring = {"q1"},
           body = {"toremoveform"}
         }

--- a/spec/03-api_spec.lua
+++ b/spec/03-api_spec.lua
@@ -37,7 +37,7 @@ describe("Plugin: request-transformer (API) [#" .. strategy .. "]", function()
             config = {
               remove = {
                 headers = {"just_a_key"},
-                headers_match = {"just_a_prefix_.*"},
+                headers_pattern = {"^just_a_prefix_"},
                 body = {"just_a_key"},
                 querystring = {"just_a_key"},
               },
@@ -50,7 +50,7 @@ describe("Plugin: request-transformer (API) [#" .. strategy .. "]", function()
         assert.response(res).has.status(201)
         local body = assert.response(res).has.jsonbody()
         assert.equals("just_a_key", body.config.remove.headers[1])
-        assert.equals("just_a_prefix_.*", body.config.remove.headers_match[1])
+        assert.equals("^just_a_prefix_", body.config.remove.headers_pattern[1])
         assert.equals("just_a_key", body.config.remove.body[1])
         assert.equals("just_a_key", body.config.remove.querystring[1])
       end)

--- a/spec/03-api_spec.lua
+++ b/spec/03-api_spec.lua
@@ -37,6 +37,7 @@ describe("Plugin: request-transformer (API) [#" .. strategy .. "]", function()
             config = {
               remove = {
                 headers = {"just_a_key"},
+                headers_match = {"just_a_prefix_.*"},
                 body = {"just_a_key"},
                 querystring = {"just_a_key"},
               },
@@ -49,6 +50,7 @@ describe("Plugin: request-transformer (API) [#" .. strategy .. "]", function()
         assert.response(res).has.status(201)
         local body = assert.response(res).has.jsonbody()
         assert.equals("just_a_key", body.config.remove.headers[1])
+        assert.equals("just_a_prefix_.*", body.config.remove.headers_match[1])
         assert.equals("just_a_key", body.config.remove.body[1])
         assert.equals("just_a_key", body.config.remove.querystring[1])
       end)


### PR DESCRIPTION
Extends the plugin to be able to remove arbitrary headers using _pattern_ matching. It's much costly hence should be used sparingly.

Interestingly, you can still spam it by sending more than 100 headers :man_shrugging: https://docs.konghq.com/2.0.x/pdk/kong.service.response/#kongserviceresponseget_headersmax_headers