### PR TITLE
feat(access) add ngx_var support for template

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can use any of the current request headers, query params, and captured URI g
 | header        | `$(headers.<header_name>)`, `$(headers["<Header-Name>"])` or `$(headers["<header-name>"])`)
 | querystring   | `$(query_params.<query-param-name>)` or `$(query_params["<query-param-name>"])`)
 | captured URIs | `$(uri_captures.<group-name>)` or `$(uri_captures["<group-name>"])`)
+| Nginx var     | `$(ngx_var.<var-name>)` or `$(ngx_var["<var-name>"])`)
 
 To escape a template, wrap it inside quotes and pass it inside another template.<br>
 `$('$(some_escaped_template)')`

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -16,6 +16,7 @@ local get_raw_body = kong.request.get_raw_body
 local set_raw_body = kong.service.request.set_raw_body
 local encode_args = ngx.encode_args
 local ngx_decode_args = ngx.decode_args
+local ngx_var = ngx.var
 local type = type
 local str_find = string.find
 local pcall = pcall
@@ -83,6 +84,9 @@ local __meta_environment = {
       uri_captures = function(self)
         return (ngx.ctx.router_matches or EMPTY).uri_captures or EMPTY
       end,
+      ngx_var = function(self)
+        return ngx_var or EMPTY
+      end,
       shared = function(self)
         return ((kong or EMPTY).ctx or EMPTY).shared or EMPTY
       end,
@@ -114,6 +118,7 @@ local function clear_environment(conf)
   rawset(template_environment, "headers", nil)
   rawset(template_environment, "query_params", nil)
   rawset(template_environment, "uri_captures", nil)
+  rawset(template_environment, "ngx_var", nil)
   rawset(template_environment, "shared", nil)
 end
 
@@ -518,7 +523,7 @@ local function transform_uri(conf)
       "` rendered to `", res, "`")
 
     if res then
-      ngx.var.upstream_uri = res
+      ngx_var.upstream_uri = res
     end
   end
 end


### PR DESCRIPTION
I made this change to support ngx.var variables in the template, below is an example to set new header `X-Customized-Header` with the Nginx variable `ngx.var.request_uri` 

```
X-Customized-Header:$(ngx_var.request_uri)
```