### PR TITLE
fix(upstream): req_uri is normalized and upstream is not escaped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ jobs:
     env: KONG_VERSION=2.1.x
   - name: Kong CE 2.2.x
     env: KONG_VERSION=2.2.x
+  - name: Kong CE 2.3.x
+    env: KONG_VERSION=2.3.x
   - name: Enterprise 2.1.4.x
     env: KONG_VERSION=2.1.4.x
   - name: Enterprise 2.2.0.x

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -23,6 +23,10 @@ local pairs = pairs
 local error = error
 local rawset = rawset
 local pl_copy_table = pl_tablex.deepcopy
+-- The library has been released on version 2.3.2
+if kong.version_num >= 2003002 then
+local escape = require("kong.tools.uri").escape
+end
 
 local _M = {}
 local template_cache = setmetatable( {}, { __mode = "k" })
@@ -518,6 +522,9 @@ local function transform_uri(conf)
       "` rendered to `", res, "`")
 
     if res then
+      if kong.version_num >= 2003002 then
+        res = escape(res)
+      end
       ngx.var.upstream_uri = res
     end
   end


### PR DESCRIPTION
Hello :wave: 

Since the normalize feature on Kong (https://github.com/Kong/kong/pull/6821), we have strange behavior on url that are decoded with special chars. 

Here an example:

- Request: `store+banne+%C3%A9lectrique.json`
- After a transform_uri: `store+banne+électrique.json`

The goal of this merge request is to fix this issue and have the expected behavior:

- Request: `store+banne+%C3%A9lectrique.json`
- After a transform_uri: `store+banne+%C3%A9lectrique.json`