### PR TITLE
fix(access) use the `kong.service.request.set_path()` PDK API instead of

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -12,6 +12,7 @@ local set_header = kong.service.request.set_header
 local get_headers = kong.request.get_headers
 local set_headers = kong.service.request.set_headers
 local set_method = kong.service.request.set_method
+local set_path = kong.service.request.set_path
 local get_raw_body = kong.request.get_raw_body
 local set_raw_body = kong.service.request.set_raw_body
 local encode_args = ngx.encode_args
@@ -518,7 +519,7 @@ local function transform_uri(conf)
       "` rendered to `", res, "`")
 
     if res then
-      ngx.var.upstream_uri = res
+      set_path(res)
     end
   end
 end

--- a/spec/02-access_spec.lua
+++ b/spec/02-access_spec.lua
@@ -111,6 +111,10 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       hosts = { "test26.test" }
     })
 
+    local route27 = bp.routes:insert({
+      hosts = { "test27.test" }
+    })
+
     bp.plugins:insert {
       route = { id = route1.id },
       name = "request-transformer",
@@ -425,6 +429,16 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
         },
         replace = {
           headers = {"x-to-Replace:false"},
+        }
+      }
+    }
+
+    bp.plugins:insert {
+      route = { id = route27.id },
+      name = "request-transformer",
+      config = {
+        replace = {
+          uri = "/requests/tést",
         }
       }
     }
@@ -1139,6 +1153,20 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.request(r).has.no.queryparam("q1")
       local value = assert.request(r).has.queryparam("q2")
       assert.equals("v2", value)
+    end)
+
+    pending("escape UTF-8 characters when replacing upstream path - enable after Kong 2.4", function()
+      local r = assert(client:send {
+        method = "GET",
+        path = "/requests/wrong_path",
+        headers = {
+          host = "test27.test"
+        }
+      })
+      assert.response(r).has.status(200)
+      local body = assert(assert.response(r).has.jsonbody())
+      assert.equals(helpers.mock_upstream_url ..
+                    "/requests/t%C3%A9st", body.url)
     end)
   end)
 


### PR DESCRIPTION
setting the `upstream_uri` variable directly to ensure special
characters are correctly escaped before sending to the upstream

This has been tested locally, however marked as `pending` until Kong 2.4 is released officially.

Discussion: https://github.com/Kong/kong/pull/6912

Sister PR: https://github.com/Kong/kong/pull/6978